### PR TITLE
allow individual AOP logs in methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ So when methods are called on beans marked with `@OblivionLoggable`, you'll see 
 
 ### Currently working on
 
-- **AOP Integration** -> *It's partially done, now I'm improving the current implementation*
+- **AOP Integration** -> *Partially done! Working on Advice Execution*
 - **Bean Definition Manipulation**
 
 ### Future work (maybe)

--- a/src/main/java/com/br/oblivion/annotations/OblivionLoggable.java
+++ b/src/main/java/com/br/oblivion/annotations/OblivionLoggable.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 // used in proxy, intercept methods and just log stuff for now
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface OblivionLoggable {
   public String name() default "";
 }

--- a/src/main/java/com/br/oblivion/util/OblivionAopProxyCreator.java
+++ b/src/main/java/com/br/oblivion/util/OblivionAopProxyCreator.java
@@ -2,8 +2,8 @@ package com.br.oblivion.util;
 
 import com.br.oblivion.annotations.OblivionLoggable;
 import com.br.oblivion.interfaces.OblivionBeanPostProcessor;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.Factory;
 import org.objenesis.Objenesis;
@@ -22,7 +22,21 @@ public class OblivionAopProxyCreator implements OblivionBeanPostProcessor {
 
   @Override
   public Object postProcessorAfterInitialization(Object bean, String beanName) {
-    if (bean.getClass().isAnnotationPresent(OblivionLoggable.class)) {
+    Method[] beanMethods = bean.getClass().getDeclaredMethods();
+
+    boolean isClassLoggable = false;
+    boolean isMethodLoggable = false;
+
+    if (bean.getClass().isAnnotationPresent(OblivionLoggable.class)) isClassLoggable = true;
+
+    for (Method m : beanMethods) {
+      if (m.isAnnotationPresent(OblivionLoggable.class)) {
+        isMethodLoggable = true;
+        break;
+      }
+    }
+
+    if (isClassLoggable || isMethodLoggable) {
       Class<?>[] beanInterfaces = bean.getClass().getInterfaces();
 
       // CGLIB proxy for beans with no suitable interfaces
@@ -34,15 +48,14 @@ public class OblivionAopProxyCreator implements OblivionBeanPostProcessor {
         Objenesis objenesis = new ObjenesisStd();
         ObjectInstantiator<?> instantiator = objenesis.getInstantiatorOf(proxyClass);
         Object proxyInstance = instantiator.newInstance();
-        ((Factory) proxyInstance).setCallback(0, new OblivionCglibInterceptor(bean));
+        ((Factory) proxyInstance)
+            .setCallback(0, new OblivionCglibInterceptor(bean, isClassLoggable));
         return proxyInstance;
       } else {
         // jdk dynamic proxy for beans with suitable interfaces
-        OblivionInvocationHandler handler = new OblivionInvocationHandler(bean);
-        System.out.println("[PROXY] interfaces -> " + Arrays.toString(beanInterfaces));
+        OblivionInvocationHandler handler = new OblivionInvocationHandler(bean, isClassLoggable);
         ClassLoader classLoader = bean.getClass().getClassLoader();
         Object proxyInstance = Proxy.newProxyInstance(classLoader, beanInterfaces, handler);
-        System.out.println("[PROXY] Created proxy instance -> " + proxyInstance.getClass());
         return proxyInstance;
       }
     }

--- a/src/main/java/com/br/oblivion/util/OblivionCglibInterceptor.java
+++ b/src/main/java/com/br/oblivion/util/OblivionCglibInterceptor.java
@@ -1,23 +1,34 @@
 package com.br.oblivion.util;
 
+import com.br.oblivion.annotations.OblivionLoggable;
 import java.lang.reflect.Method;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 
 public class OblivionCglibInterceptor implements MethodInterceptor {
   private final Object originalTarget;
+  private boolean isClassLoggable;
 
-  public OblivionCglibInterceptor(Object originalTarget) {
+  public OblivionCglibInterceptor(Object originalTarget, boolean isClassLoggable) {
     this.originalTarget = originalTarget;
+    this.isClassLoggable = isClassLoggable;
   }
 
   @Override
   public Object intercept(Object obj, Method method, Object[] args, MethodProxy proxy)
       throws Throwable {
-    System.out.println("[GCLIB PROXY] intercepting method -> " + method.getName());
     try {
+      if (method.isAnnotationPresent(OblivionLoggable.class) || isClassLoggable) {
+        System.out.println("[GCLIB PROXY] intercepting method -> " + method.getName());
+      }
+
       Object result = method.invoke(this.originalTarget, args);
-      System.out.println("[CGLIB PROXY] finished method -> " + method.getName());
+
+      if (method.isAnnotationPresent(OblivionLoggable.class) || isClassLoggable) {
+        System.out.println("[GCLIB PROXY] intercepting method -> " + method.getName());
+        System.out.println("[CGLIB PROXY] finished method -> " + method.getName());
+      }
+
       return result;
     } catch (Throwable t) {
       System.out.println("[CGLIB PROXY] exception in method -> " + method.getName());

--- a/src/main/java/com/br/oblivion/util/OblivionInvocationHandler.java
+++ b/src/main/java/com/br/oblivion/util/OblivionInvocationHandler.java
@@ -1,22 +1,40 @@
 package com.br.oblivion.util;
 
+import com.br.oblivion.annotations.OblivionLoggable;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 public class OblivionInvocationHandler implements InvocationHandler {
   private final Object originalTarget;
+  private boolean isClassLoggable;
 
-  public OblivionInvocationHandler(Object originalTarget) {
+  public OblivionInvocationHandler(Object originalTarget, boolean isClassLoggable) {
     this.originalTarget = originalTarget;
+    this.isClassLoggable = isClassLoggable;
   }
 
   @Override
   public Object invoke(Object obj, Method method, Object[] args)
-      throws IllegalAccessException, InvocationTargetException {
-    System.out.println("[PROXY] intercepting method -> " + method.getName());
-    Object result = method.invoke(this.originalTarget, args);
-    System.out.println("[PROXY] finished method -> " + method.getName());
-    return result;
+      throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    try {
+      Method originalMethod =
+          this.originalTarget.getClass().getMethod(method.getName(), method.getParameterTypes());
+
+      if (originalMethod.isAnnotationPresent(OblivionLoggable.class) || isClassLoggable) {
+        System.out.println("[PROXY] intercepting method -> " + method.getName());
+      }
+
+      Object result = method.invoke(this.originalTarget, args);
+
+      if (originalMethod.isAnnotationPresent(OblivionLoggable.class) || isClassLoggable) {
+        System.out.println("[PROXY] finished method -> " + method.getName());
+      }
+
+      return result;
+    } catch (Throwable t) {
+      System.out.println("[PROXY] exception in method -> " + method.getName());
+      throw t;
+    }
   }
 }

--- a/src/main/java/com/br/samples/productApp/repository/DatabaseProductRepository.java
+++ b/src/main/java/com/br/samples/productApp/repository/DatabaseProductRepository.java
@@ -1,5 +1,6 @@
 package com.br.samples.productApp.repository;
 
+import com.br.oblivion.annotations.OblivionLoggable;
 import com.br.oblivion.annotations.OblivionService;
 import com.br.samples.productApp.domain.Product;
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+@OblivionLoggable
 @OblivionService(name = "DBREPO")
 public class DatabaseProductRepository implements ProductRepository, TrackableRepository {
   private final Map<String, Product> database = new ConcurrentHashMap<>();

--- a/src/main/java/com/br/samples/productApp/service/DefaultProductService.java
+++ b/src/main/java/com/br/samples/productApp/service/DefaultProductService.java
@@ -1,12 +1,5 @@
 package com.br.samples.productApp.service;
 
-import com.br.oblivion.annotations.OblivionLoggable;
-import com.br.oblivion.annotations.OblivionPostConstruct;
-import com.br.oblivion.annotations.OblivionPostInitialization;
-import com.br.oblivion.annotations.OblivionPostShutdown;
-import com.br.oblivion.annotations.OblivionPreDestroy;
-import com.br.oblivion.annotations.OblivionPreInitialization;
-import com.br.oblivion.annotations.OblivionPreShutdown;
 import com.br.oblivion.annotations.OblivionPrototype;
 import com.br.oblivion.annotations.OblivionQualifier;
 import com.br.oblivion.annotations.OblivionService;
@@ -18,7 +11,6 @@ import java.util.UUID;
 
 @OblivionService
 @OblivionPrototype
-@OblivionLoggable
 public class DefaultProductService {
 
   private final ProductRepository repository;
@@ -27,36 +19,6 @@ public class DefaultProductService {
     System.out.println(
         "DefaultProductService created with repository: " + repository.getClass().getSimpleName());
     this.repository = repository;
-  }
-
-  @OblivionPreInitialization
-  public static void a() {
-    System.out.println("OblivionPreInitialization");
-  }
-
-  @OblivionPostConstruct
-  public void b() {
-    System.out.println("OblivionPostConstruct");
-  }
-
-  @OblivionPostInitialization
-  public void c() {
-    System.out.println("OblivionPostInitialization");
-  }
-
-  @OblivionPreDestroy
-  public void d() {
-    System.out.println("OblivionPreDestroy");
-  }
-
-  @OblivionPreShutdown
-  public void e() {
-    System.out.println("OblivionPreShutdown");
-  }
-
-  @OblivionPostShutdown
-  public void f() {
-    System.out.println("OblivionPostShutdown");
   }
 
   public Product createProduct(String name) {


### PR DESCRIPTION
Now we can either mark a class with `@OblivionLoggable` and log all methods, or we can use the same annotation on methods to log only the marked ones

`@OblivionLoggable` will be renamed to `@OblivionAround`, since it already wraps fully an intercepted method, and only the `proceed()` implementation for it is pending.

And I'm currently working on other advices such as `@OblivionBefore`, `@OblivionAfter`, `@OblivionAfterReturning`, `@OblivionAfterThrowing` and `@OblivionLoggable` that will become `@OblivionAround`.