### PR TITLE
allow advices to be defined in separated aspect beans

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ public class MyLoggingAspect {
 - **AOP Integration**
 
   - JoinPoints;
-  - Allow Advice Calls from Outside the "Callable Methods";
+  - Allow Advice Calls from Outside the "Callable Methods"; **DONE :)**
   - Advanced Pointcut Expressions;
   
 - **Bean Definition Manipulation**

--- a/src/main/java/com/br/oblivion/container/BeansContainer.java
+++ b/src/main/java/com/br/oblivion/container/BeansContainer.java
@@ -37,10 +37,12 @@ public class BeansContainer {
   public static Map<String, Class<?>> configBeans = new HashMap<>();
 
   // AOP advices
-  public static Map<String, List<Method>> beforeAdviceMap = new ConcurrentHashMap<>();
-  public static Map<String, List<Method>> afterAdviceMap = new ConcurrentHashMap<>();
-  public static Map<String, List<Method>> afterThrowingAdviceMap = new ConcurrentHashMap<>();
-  public static Map<String, List<Method>> afterReturningAdviceMap = new ConcurrentHashMap<>();
+  public static Map<String, List<Pair<Method, Object>>> beforeAdviceMap = new ConcurrentHashMap<>();
+  public static Map<String, List<Pair<Method, Object>>> afterAdviceMap = new ConcurrentHashMap<>();
+  public static Map<String, List<Pair<Method, Object>>> afterThrowingAdviceMap =
+      new ConcurrentHashMap<>();
+  public static Map<String, List<Pair<Method, Object>>> afterReturningAdviceMap =
+      new ConcurrentHashMap<>();
 
   public <T> void registerSingletonBean(String identifier, T bean) {
     singletonBeans.put(identifier, bean);

--- a/src/main/java/com/br/oblivion/interfaces/TargetAware.java
+++ b/src/main/java/com/br/oblivion/interfaces/TargetAware.java
@@ -1,0 +1,6 @@
+package com.br.oblivion.interfaces;
+
+// aop proxy
+public interface TargetAware {
+  Object getOblivionTargetInstance();
+}

--- a/src/main/java/com/br/oblivion/util/Inject.java
+++ b/src/main/java/com/br/oblivion/util/Inject.java
@@ -9,6 +9,7 @@ import com.br.oblivion.annotations.OblivionPrototype;
 import com.br.oblivion.annotations.OblivionService;
 import com.br.oblivion.annotations.OblivionWire;
 import com.br.oblivion.container.BeansContainer;
+import com.br.oblivion.container.Pair;
 import com.br.oblivion.interfaces.OblivionBeanPostProcessor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -57,12 +58,21 @@ public class Inject {
             targetMethod = m.getAnnotation(OblivionBefore.class).target();
 
             if (BeansContainer.beforeAdviceMap.containsKey(targetMethod)) {
-              List<Method> existingMethods = BeansContainer.beforeAdviceMap.get(targetMethod);
-              existingMethods.add(m);
+              List<Pair<Method, Object>> existingMethods =
+                  BeansContainer.beforeAdviceMap.get(targetMethod);
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pair = new Pair<Method, Object>(m, aspectInstance);
+              existingMethods.add(pair);
             } else {
-              List<Method> methodToAdd = new ArrayList<>();
-              methodToAdd.add(m);
-              BeansContainer.beforeAdviceMap.put(targetMethod, methodToAdd);
+              List<Pair<Method, Object>> pairList = new ArrayList<>();
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pairToAdd = new Pair<Method, Object>(m, aspectInstance);
+              pairList.add(pairToAdd);
+              BeansContainer.beforeAdviceMap.put(targetMethod, pairList);
             }
           }
 
@@ -70,12 +80,21 @@ public class Inject {
             targetMethod = m.getAnnotation(OblivionAfter.class).target();
 
             if (BeansContainer.afterAdviceMap.containsKey(targetMethod)) {
-              List<Method> existingMethods = BeansContainer.afterAdviceMap.get(targetMethod);
-              existingMethods.add(m);
+              List<Pair<Method, Object>> existingMethods =
+                  BeansContainer.afterAdviceMap.get(targetMethod);
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pair = new Pair<Method, Object>(m, aspectInstance);
+              existingMethods.add(pair);
             } else {
-              List<Method> methodToAdd = new ArrayList<>();
-              methodToAdd.add(m);
-              BeansContainer.afterAdviceMap.put(targetMethod, methodToAdd);
+              List<Pair<Method, Object>> pairList = new ArrayList<>();
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pairToAdd = new Pair<Method, Object>(m, aspectInstance);
+              pairList.add(pairToAdd);
+              BeansContainer.afterAdviceMap.put(targetMethod, pairList);
             }
           }
 
@@ -83,13 +102,21 @@ public class Inject {
             targetMethod = m.getAnnotation(OblivionAfterThrowing.class).target();
 
             if (BeansContainer.afterThrowingAdviceMap.containsKey(targetMethod)) {
-              List<Method> existingMethods =
+              List<Pair<Method, Object>> existingMethods =
                   BeansContainer.afterThrowingAdviceMap.get(targetMethod);
-              existingMethods.add(m);
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pair = new Pair<Method, Object>(m, aspectInstance);
+              existingMethods.add(pair);
             } else {
-              List<Method> methodToAdd = new ArrayList<>();
-              methodToAdd.add(m);
-              BeansContainer.afterThrowingAdviceMap.put(targetMethod, methodToAdd);
+              List<Pair<Method, Object>> pairList = new ArrayList<>();
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pairToAdd = new Pair<Method, Object>(m, aspectInstance);
+              pairList.add(pairToAdd);
+              BeansContainer.afterThrowingAdviceMap.put(targetMethod, pairList);
             }
           }
 
@@ -97,13 +124,21 @@ public class Inject {
             targetMethod = m.getAnnotation(OblivionAfterReturning.class).target();
 
             if (BeansContainer.afterReturningAdviceMap.containsKey(targetMethod)) {
-              List<Method> existingMethods =
+              List<Pair<Method, Object>> existingMethods =
                   BeansContainer.afterReturningAdviceMap.get(targetMethod);
-              existingMethods.add(m);
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, scannedClasses, null, false);
+              Pair<Method, Object> pair = new Pair<Method, Object>(m, aspectInstance);
+              existingMethods.add(pair);
             } else {
-              List<Method> methodToAdd = new ArrayList<>();
-              methodToAdd.add(m);
-              BeansContainer.afterReturningAdviceMap.put(targetMethod, methodToAdd);
+              List<Pair<Method, Object>> pairList = new ArrayList<>();
+              Object aspectInstance =
+                  beansContainer.resolveDependency(
+                      ac, ac.getName(), threadPoolExecutor, adviceClasses, null, false);
+              Pair<Method, Object> pairToAdd = new Pair<Method, Object>(m, aspectInstance);
+              pairList.add(pairToAdd);
+              BeansContainer.afterReturningAdviceMap.put(targetMethod, pairList);
             }
           }
         }

--- a/src/main/java/com/br/samples/productApp/cli/ProductCLI.java
+++ b/src/main/java/com/br/samples/productApp/cli/ProductCLI.java
@@ -1,6 +1,7 @@
 package com.br.samples.productApp.cli;
 
 import com.br.oblivion.annotations.OblivionAspect;
+import com.br.oblivion.annotations.OblivionBefore;
 import com.br.oblivion.annotations.OblivionService;
 import com.br.samples.productApp.domain.Product;
 import com.br.samples.productApp.service.DefaultProductService;
@@ -27,10 +28,15 @@ public class ProductCLI {
     this.scanner = new Scanner(System.in);
   }
 
-  // @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.save")
-  // public void beforeOut() {
-  //   System.out.println("BEFORE SAVE, BUT CALLED FROM OUTSIDE");
-  // }
+  @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.save")
+  public void beforeOut() {
+    System.out.println("BEFORE SAVE, BUT CALLED FROM OUTSIDE");
+  }
+
+  @OblivionBefore(target = "com.br.samples.productApp.service.DefaultProductService.show")
+  public void beforeShow() {
+    System.out.println("BEFORE SHOW, BUT CALLED FROM OUTSIDE");
+  }
 
   public void run() {
     System.out.println("\n--- Product Management ---");

--- a/src/main/java/com/br/samples/productApp/repository/DatabaseProductRepository.java
+++ b/src/main/java/com/br/samples/productApp/repository/DatabaseProductRepository.java
@@ -1,13 +1,11 @@
 package com.br.samples.productApp.repository;
 
-import com.br.oblivion.annotations.OblivionAfter;
-import com.br.oblivion.annotations.OblivionAfterReturning;
-import com.br.oblivion.annotations.OblivionAfterThrowing;
 import com.br.oblivion.annotations.OblivionAspect;
 import com.br.oblivion.annotations.OblivionBefore;
 import com.br.oblivion.annotations.OblivionLoggable;
 import com.br.oblivion.annotations.OblivionService;
 import com.br.samples.productApp.domain.Product;
+import com.br.samples.productApp.service.DefaultProductService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +21,7 @@ public class DatabaseProductRepository implements ProductRepository, TrackableRe
   @OblivionLoggable
   public void save(Product product) {
     // System.out.println("[DB REPO] Saving product to database: " + product);
+    DefaultProductService.show();
     database.put(product.getId(), product);
   }
 
@@ -32,50 +31,30 @@ public class DatabaseProductRepository implements ProductRepository, TrackableRe
     return Optional.ofNullable(database.get(id));
   }
 
-  // when its an implementation of an interface, we target the method in the repository
-  @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
+  // now instead of setting the function in the interface here, we must pass the current
+  // implementation, since im no more running function based on the class i'm at, but instead
+  // im storing the object instance in a map, we can see this in the beginning of the BeansContainer
+  // file:
+  //
+  // public static Map<String, List<Pair<Method, Object>>> beforeAdviceMap = new
+  // ConcurrentHashMap<>();
+  //
+  // if an interface is provided as a target, oblivion wont be able to run, because theres no
+  // way to run a method on a interface
+  @OblivionBefore(target = "com.br.samples.productApp.repository.DatabaseProductRepository.findAll")
   public void beforeFindAll() {
     System.out.println("[PROXY BEFORE 1] LOGGING BEFORE findAll");
   }
 
-  @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
+  @OblivionBefore(target = "com.br.samples.productApp.repository.DatabaseProductRepository.findAll")
   public void beforeFindAll2() {
     System.out.println("[PROXY BEFORE 2] LOGGING BEFORE findAll");
   }
 
-  @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.save")
+  // @OblivionBefore(target = "com.br.samples.productApp.repository.ProductRepository.save")
+  @OblivionBefore(target = "com.br.samples.productApp.repository.DatabaseProductRepository.save")
   public void beforeSave() {
     System.out.println("[PROXY BEFORE 3 - SAVE] LOGGING BEFORE save");
-  }
-
-  @OblivionAfter(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterFindAll() {
-    System.out.println("[AFTER ADVICE 1! Logging after 'findAll']");
-  }
-
-  @OblivionAfter(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterFindAll2() {
-    System.out.println("[AFTER ADVICE 2! Logging after 'findAll']");
-  }
-
-  @OblivionAfterThrowing(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterThrowingFindAll() {
-    System.out.println("[AFTER THROWING ADVICE 1! Logging after throwing 'findAll']");
-  }
-
-  @OblivionAfterThrowing(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterThrowingFindAll2() {
-    System.out.println("[AFTER THROWING ADVICE 2! Logging after throwing 'findAll']");
-  }
-
-  @OblivionAfterReturning(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterReturningFindAll() {
-    System.out.println("[AFTER RETURNING ADVICE 1! Logging after returning 'findAll']");
-  }
-
-  @OblivionAfterReturning(target = "com.br.samples.productApp.repository.ProductRepository.findAll")
-  public void afterReturningFindAll2() {
-    System.out.println("[AFTER RETURNING ADVICE 2! Logging after returning 'findAll']");
   }
 
   @Override

--- a/src/main/java/com/br/samples/productApp/service/DefaultProductService.java
+++ b/src/main/java/com/br/samples/productApp/service/DefaultProductService.java
@@ -1,5 +1,8 @@
 package com.br.samples.productApp.service;
 
+import com.br.oblivion.annotations.OblivionAspect;
+import com.br.oblivion.annotations.OblivionBefore;
+import com.br.oblivion.annotations.OblivionLoggable;
 import com.br.oblivion.annotations.OblivionPrototype;
 import com.br.oblivion.annotations.OblivionQualifier;
 import com.br.oblivion.annotations.OblivionService;
@@ -9,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-// @OblivionAspect
+@OblivionAspect
 @OblivionService
 @OblivionPrototype
 public class DefaultProductService {
@@ -34,11 +37,15 @@ public class DefaultProductService {
     return repository.findById(id);
   }
 
-  // @OblivionBefore(target =
-  // "com.br.samples.productApp.service.DefaultProductService.getAllProducts")
-  // public void beforeGetAllProducts() {
-  //   System.out.println("[BEFORE ADVICE! Logging before 'getAllProducts']");
-  // }
+  @OblivionLoggable
+  public static void show() {
+    System.out.println("CALLING SHOW");
+  }
+
+  @OblivionBefore(target = "com.br.samples.productApp.service.DefaultProductService.getAllProducts")
+  public void beforeGetAllProducts() {
+    System.out.println("NO INTERFACE ** [BEFORE ADVICE! Logging before 'getAllProducts']");
+  }
 
   // @OblivionAfter(target =
   // "com.br.samples.productApp.service.DefaultProductService.getAllProducts")
@@ -58,7 +65,7 @@ public class DefaultProductService {
   //   System.out.println("[AFTER RETURNING ADVICE! Logging after returning 'getAllProducts']");
   // }
 
-  // @OblivionLoggable
+  @OblivionLoggable
   public List<Product> getAllProducts() {
     // int x = 1 / 0; // just testing a throw for AfterThrowing
     return repository.findAll();


### PR DESCRIPTION
this also fixes cglib interceptions intercepting the internal 'getOblivionTargetInstance' function...

i explain this problem in the jdk handle file, but since it's not a problem there, i left the solution commented there just in case.